### PR TITLE
Need to install dependency before psycopg2.

### DIFF
--- a/datascience/postgres_connection.md
+++ b/datascience/postgres_connection.md
@@ -27,7 +27,8 @@
   * activate-data-science
   * you should now see this prompt in your terminal session: '(data-science) hack@hackoregon-base'
   
-2. Use pip to install psycopg2 using the following command
+2. Use pip to install psycopg2 and its dependencies using the following commands
+  * sudo apt-get install libpq-dev
   * pip install psycopg2
   
 #### You now have the pieces needed to connect to the DB using Jupyter Notebook. Open a Jupyter Notebook by following the steps below.


### PR DESCRIPTION
Before I installed the dependency, I received an error message:

Error: b'You need to install postgresql-server-dev-X.Y for building a server-side extension or libpq-dev for building a client-side application.\n'

After I installed the dependency, I was able to follow the rest of the instructions and the snippet of code connected to the PostgreSQL instance.